### PR TITLE
Add a custom domain used with bandcamp.com

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -104,7 +104,8 @@
                 "data/orchestrator.js"
             ],
             "matches": [
-                "*://*.bandcamp.com/*"
+                "*://*.bandcamp.com/*",
+                "*://shop.attackthemusic.com/*"
             ]
         },
         {


### PR DESCRIPTION
I understand if you prefer not to add this, as there are likely 100s of sites that could be on this list.

However, I added this for my own use, so I thought I may as well open this PR :).