### PR TITLE
Add support for beta.music.apple.com

### DIFF
--- a/data/music.apple.com-view.js
+++ b/data/music.apple.com-view.js
@@ -1,0 +1,9 @@
+/**
+ * MediaKeys namespace.
+ */
+if (typeof MediaKeys == "undefined") var MediaKeys = {};
+
+MediaKeys.playButton = "//button[@data-test-playback-control-play]";
+MediaKeys.pauseButton = "//button[@data-test-playback-control-pause]";
+MediaKeys.skipButton = "//button[@data-test-playback-control-next]";
+MediaKeys.previousButton = "//button[@data-test-playback-control-previous]";

--- a/manifest.json
+++ b/manifest.json
@@ -99,6 +99,17 @@
         {
             "js": [
                 "lib/browser-polyfill.min.js",
+                "data/music.apple.com-view.js",
+                "data/finder.js",
+                "data/orchestrator.js"
+            ],
+            "matches": [
+                "*://*.music.apple.com/*"
+            ]
+        },
+        {
+            "js": [
+                "lib/browser-polyfill.min.js",
                 "data/bandcamp.com-view.js",
                 "data/finder.js",
                 "data/orchestrator.js"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "pandora": "web-ext run --url https://www.pandora.com/station/play/3576905106862450009 --browser-console",
     "youtube": "web-ext run --url https://www.youtube.com/watch?v=hKitZEncwro --pref=javascript.options.strict=false --browser-console",
     "spotify": "web-ext run --url https://open.spotify.com --browser-console",
+    "apple": "web-ext run --url https://beta.music.apple.com --browser-console",
     "debug": "web-ext run --browser-console",
     "build": "web-ext build",
     "deploy": "web-ext sign --channel=listed",


### PR DESCRIPTION
### Apple Music
https://beta.music.apple.com

I'm making a guess here: Once Apple Music web goes out of beta, they will remove the `beta.` part from the URL and this code should continue to work.

Successfully tested using:
1. `npm run apple`
2. Logging into Apple Music
3. Waiting/Reloading until Firefox has installed DRM components
4. Starting a playlist
5. Pressing media keys on keyboard