### PR TITLE
updated css selectors for deezer

### DIFF
--- a/data/deezer.com-view.js
+++ b/data/deezer.com-view.js
@@ -3,7 +3,7 @@
  */
 if (typeof MediaKeys == 'undefined') var MediaKeys = {};
 let basePlayer = 'div#page_player ';
-MediaKeys.playButton = basePlayer + 'button .icon-play';
-MediaKeys.pauseButton = basePlayer + 'button .icon-pause';
-MediaKeys.skipButton = basePlayer + 'button .icon-next';
-MediaKeys.previousButton = basePlayer + 'button .icon-prev';
+MediaKeys.playButton = basePlayer + 'button .svg-icon-play';
+MediaKeys.pauseButton = basePlayer + 'button .svg-icon-pause';
+MediaKeys.skipButton = basePlayer + 'button .svg-icon-next';
+MediaKeys.previousButton = basePlayer + 'button .svg-icon-prev';


### PR DESCRIPTION
The previous css selectors for deezer do not work anymore.
I updated `deezer.com-view.js` to use the new css class names.